### PR TITLE
Fix Makefile.Ubuntu to use $BASE instead of $HOME

### DIFF
--- a/Makefile.Ubuntu
+++ b/Makefile.Ubuntu
@@ -1,7 +1,7 @@
 BUILD_TYPE := debug
 PLATFORM   := x86
 MACHINE := x86
-LUNA_STAGING := $(HOME)/luna-desktop-binaries/staging
+LUNA_STAGING := $(BASE)/staging
 
 NOVA_TOP_DIR_REL = ../
 NOVA_TOP_DIR_ABS = $(shell cd $(NOVA_TOP_DIR_REL); pwd)
@@ -15,4 +15,3 @@ LIBS := -L$(LUNA_STAGING)/lib\
 ARCH_CFLAGS := -DDESKTOP=1
 
 include Makefile.inc
-


### PR DESCRIPTION
The build script (build-desktop) failed if you had set $BASE to something else than $(HOME)/luna-desktop-binaries
